### PR TITLE
debug:自动加载api下路由文件

### DIFF
--- a/src/Http.php
+++ b/src/Http.php
@@ -268,13 +268,9 @@ class Http
         }
 
         if ($appRootNamespace == 'api') {
-            // 加载核心应用公共语言包
-            $coreApps = ['home', 'user'];
-            foreach ($coreApps as $app) {
-                $routeFile = "{$rootPath}vendor/thinkcmf/cmf-api/src/{$app}/route.php";
-                if (is_file($routeFile)) {
-                    include $routeFile;
-                }
+            $routeFile = "{$rootPath}vendor/thinkcmf/cmf-api/src/route.php";
+            if (is_file($routeFile)) {
+                include $routeFile;
             }
         }
 


### PR DESCRIPTION
使用thinkcmf/cmf-api:^6.0.0/route.php的自动引入路由功能，而不是只引入home user模块路由

api/*/route.php are not effective, found something in debug:
1. automatic scanning in thinkcmf/cmf-api:^6.0.0/route.php 
2. but thinkcmf/cmf-route:^6.0.0/Http.php  line271-277, just include ‘home’ and ‘user’, rather than 'thinkcmf/cmf-api:^6.0.0/route.php '
hope we all think this adjustment is more effective!